### PR TITLE
REPO-3656: AWS Load Tests: Docker images for the BMF components

### DIFF
--- a/.maven-dockerignore
+++ b/.maven-dockerignore
@@ -1,0 +1,1 @@
+target/docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Image provides a container that runs alfresco-bm-rest-api to create scenarios on Alfresco Enterprise Content Services.
+
+ # Fetch image based on Java 8
+ FROM alfresco/alfresco-base-java:8
+
+ COPY target/alfresco-bm-rest-api-${docker.project_version}.jar /usr/bin
+ RUN ln /usr/bin/alfresco-bm-rest-api-${docker.project_version}.jar /usr/bin//alfresco-bm-rest-api.jar
+
+ ENV JAVA_OPTS=""
+ ENTRYPOINT java $JAVA_OPTS -jar /usr/bin/alfresco-bm-rest-api.jar

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,12 @@
     <properties>
         <junit.version>4.11</junit.version>
         <dependency.server.version>3.0.0-SNAPSHOT</dependency.server.version>
-    </properties>
+        <dependency.fabric8.version>3.5.37</dependency.fabric8.version>
+        <image.name>alfresco/alfresco-bm-rest-api</image.name>
+        <image.tag>latest</image.tag>
+        <image.registry>quay.io</image.registry>
+        <docker.project_version>${project.version}</docker.project_version>
+	</properties>
 
     <dependencies>
         <dependency>
@@ -103,8 +108,136 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <plugin>
+                 <groupId>io.fabric8</groupId>
+                 <artifactId>fabric8-maven-plugin</artifactId>
+                 <version>${dependency.fabric8.version}</version>
+                 <configuration>
+                     <images>
+                         <image>
+                             <name>${image.name}:${image.tag}</name>
+                             <build>
+                                 <dockerFileDir>${project.basedir}/</dockerFileDir>
+                             </build>
+                         </image>
+                     </images>
+                 </configuration>
+             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>internal</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${dependency.fabric8.version}</version>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${image.registry}/${image.name}:${image.tag}</name>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-push-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <!-- <goal>push</goal> -->
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>master</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${dependency.fabric8.version}</version>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${image.registry}/${image.name}</name>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                    </build>
+                                </image>
+                                <image>
+                                    <name>${image.name}</name>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-push-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${dependency.fabric8.version}</version>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${image.name}:${project.version}</name>
+                                    <registry>${image.registry}</registry>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                    </build>
+                                </image>
+                                <image>
+                                    <name>${image.name}:${project.version}</name>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-push-image</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
-
-


### PR DESCRIPTION
Added support for creating docker images using fabric8 plugin.
Currently, the internal profile only build the image locally.