### PR TITLE
REPO-3661: Use the AbstractRestApiEventProcessor as base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <junit.version>4.11</junit.version>
         <dependency.spring-boot.version>1.5.12.RELEASE</dependency.spring-boot.version>
-        <dependency.server.version>3.0.1</dependency.server.version>
+        <dependency.server.version>3.0.2</dependency.server.version>
         <dependency.fabric8.version>3.5.37</dependency.fabric8.version>
         <image.name>alfresco/alfresco-bm-rest-api</image.name>
         <image.tag>latest</image.tag>

--- a/src/main/java/org/alfresco/bm/rest/CreateNodeTest.java
+++ b/src/main/java/org/alfresco/bm/rest/CreateNodeTest.java
@@ -34,15 +34,10 @@ import org.apache.commons.lang.RandomStringUtils;
 public class CreateNodeTest extends RestTest
 {
 
-    public CreateNodeTest(String baseUrl)
-    {
-        super(baseUrl);
-    }
-
     @Override
     protected void prepareData() throws Exception
     {
-        restClient.authenticateUser(new UserModel(alfrescoAdminUsername, alfrescoAdminPassword));
+        getRestWrapper().authenticateUser(new UserModel(alfrescoAdminUsername, alfrescoAdminPassword));
     }
 
     @Override
@@ -52,8 +47,7 @@ public class CreateNodeTest extends RestTest
         node.setName(RandomStringUtils.randomAlphanumeric(8));
         node.setNodeType("cm:folder");
 
-        restClient.withParams("autoRename=true").withCoreAPI().usingNode(ContentModel.my()).createNode(node);
-
+        getRestWrapper().withParams("autoRename=true").withCoreAPI().usingNode(ContentModel.my()).createNode(node);
     }
 
 }

--- a/src/main/java/org/alfresco/bm/rest/RestRequestsTest.java
+++ b/src/main/java/org/alfresco/bm/rest/RestRequestsTest.java
@@ -25,14 +25,14 @@
  */
 package org.alfresco.bm.rest;
 
-import org.alfresco.bm.common.EventResult;
-import org.alfresco.bm.driver.event.AbstractEventProcessor;
-import org.alfresco.bm.driver.event.Event;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class RestRequestsTest extends AbstractEventProcessor
+import org.alfresco.bm.AbstractRestApiEventProcessor;
+import org.alfresco.bm.common.EventResult;
+import org.alfresco.bm.driver.event.Event;
+
+public class RestRequestsTest extends AbstractRestApiEventProcessor
 {
 
     private String eventName;
@@ -63,5 +63,4 @@ public class RestRequestsTest extends AbstractEventProcessor
 
         return new EventResult(event.getName(), nextEvents);
     }
-
 }

--- a/src/main/resources/config/spring/test-context.xml
+++ b/src/main/resources/config/spring/test-context.xml
@@ -4,8 +4,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-    <!-- alfresco-benchmark-bm-sample: [Project description] -->
-
     <!-- Import any application contexts for test runs -->
     <import resource="classpath:config/spring/test-common-context.xml"/>
 
@@ -13,8 +11,7 @@
     <!-- Reporting -->
     <!-- -->
     <!-- The CompletionEstimator looking at the process count results -->
-    <bean id="completionEstimator"
-          class="org.alfresco.bm.driver.test.EventCountCompletionEstimator">
+    <bean id="completionEstimator" class="org.alfresco.bm.driver.test.EventCountCompletionEstimator">
         <constructor-arg name="eventService" ref="eventService"/>
         <constructor-arg name="resultService" ref="resultService"/>
         <constructor-arg name="eventName" value="start"/>
@@ -25,7 +22,7 @@
     <!-- EventProcessors -->
     <!-- -->
     <bean id="event.base.rest.api" abstract="true" parent="event.base">
-        <constructor-arg name="baseUrl" value="${alfresco.url}"/>
+        <property name="baseUrl" value="${alfresco.url}"/>
         <property name="alfrescoAdminUsername" value="${alfresco.adminUser}"/>
         <property name="alfrescoAdminPassword" value="${alfresco.adminPwd}"/>
     </bean>
@@ -40,7 +37,6 @@
     <bean id="event.createNode" class="org.alfresco.bm.rest.CreateNodeTest"
           parent="event.base.rest.api">
     </bean>
-
 
     <bean id="producer.responsivenessChecked"
           class="org.alfresco.bm.driver.event.producer.TerminateEventProducer"


### PR DESCRIPTION
Use the `AbstractRestApiEventProcessor` as base for the event processor that do REST API calls (using TAS).